### PR TITLE
Bugfix: initialisation des variables

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,14 +1,35 @@
-const dino = document.getElementById('dino');
-const cactus = document.getElementById('cactus')
+// On déclare les variables dino et cactus pour qu'elles soient globales
+// (accessibles depuis l'ensemble du fichier), mais on ne peut pas les
+// initialiser pour l'instant, car la page n'est probablement pas encore chargée
+// (les variables vaudraient null si on faisait cela). On va initialiser les
+// variables dans une fonction d'initialisation, *APRÈS* le chargement de la
+// page.
 
+let dino;
+let cactus;
 
-function saut () {
-    if (dino.classList != 'saut') {
+function saut (event) {
+    const key = event.key;
+
+    // On ne saut que si on n'est pas déjà en train de sauter, et uniquement si
+    // la touche SPACE est appuyée.
+    if (key === ' ' && !dino.classList.contains('saut')) {
         dino.classList.add('saut');
         setTimeout(function () {
             dino.classList.remove('saut');
         }, 300);
     }
+}
+
+function initialisation() {
+    // Fonction d'initialisation, appelée après le chargement de la page (au
+    // bout du script).
+
+    dino = document.getElementById('dino');
+    cactus = document.getElementById('cactus')
+    
+    document.addEventListener('keydown', saut);
+    
 }
 
 /* Avec ce bout de code la console ne fait que mettre des erreurs   
@@ -23,6 +44,8 @@ let estVivant = setInterval(function () {
     
 }, 10); */
 
-document.addEventListener('keydown', function (event) {
-    saut();
-});
+
+
+// On demande au navigateur d'appeler la fonction d'initialisation après avoir
+// chargé la page.
+window.addEventListener('load', () => initialisation());


### PR DESCRIPTION
* Les variables dino et cactus étaient initialisées trop tôt (avant le chargement de la page)
* La façon de tester si dino avait la classe 'saut' était incorrect: classList est une liste, il faut tester si elle *contient* saut (ou pas)
* On a rajouté une condition pour que le saut ne s'effectue qu'avec une touche bien précise (barre d'espace pour l'instant, mais on peut le changer)